### PR TITLE
Fix account registering always show email invalid

### DIFF
--- a/enet server test/enet server test.cpp
+++ b/enet server test/enet server test.cpp
@@ -2338,7 +2338,7 @@ int _tmain(int argc, _TCHAR* argv[])
 								if (infoDat[0] == "username") username = infoDat[1];
 								if (infoDat[0] == "password") password = infoDat[1];
 								if (infoDat[0] == "passwordverify") passwordverify = infoDat[1];
-								if (infoDat[0] == "email") email = email[1];
+								if (infoDat[0] == "email") email = infoDat[1];
 								if (infoDat[0] == "discord") discord = infoDat[1];
 							}
 						}


### PR DESCRIPTION
Should be infoDat instead of email (which is a blank string)