### PR TITLE
Fix OnConsoleMessage in sendPlayerLeave

### DIFF
--- a/enet server test/enet server test.cpp
+++ b/enet server test/enet server test.cpp
@@ -1793,7 +1793,7 @@ void SendPacketRaw(int a1, void *packetData, size_t packetDataSize, void *a4, EN
 	{
 		ENetPeer * currentPeer;
 		GamePacket p = packetEnd(appendString(appendString(createPacket(), "OnRemove"), "netID|" + std::to_string(player->netID) + "\n")); // ((PlayerInfo*)(server->peers[i].data))->tankIDName
-		GamePacket p2 = packetEnd(appendString(appendString(createPacket(), "OnConsoleMessage"), "`5<`w" + player->displayName + "`` left, `w" + std::to_string(getPlayersCountInWorld(player->currentWorld)) + "`` others here>``"));
+		GamePacket p2 = packetEnd(appendString(appendString(createPacket(), "OnConsoleMessage"), "`5<`w" + player->displayName + "`` left, `w" + std::to_string(getPlayersCountInWorld(player->currentWorld) - 1) + "`` others here>``"));
 		for (currentPeer = server->peers;
 			currentPeer < &server->peers[server->peerCount];
 			++currentPeer)


### PR DESCRIPTION
On console message displays:
`<(Only person on the server) left, 1 others here>`

But it should display:
`<(Only person on the server) left, 0 others here>`

So by subtracting 1 from the `getPlayersCountInWorld()` call in the sendPlayerLeave we get correct amount displaying.